### PR TITLE
Fix for Twig's SimpleTest failing in Craft 2788

### DIFF
--- a/utensils/vendor/twig/twig/lib/Twig/SimpleTest.php
+++ b/utensils/vendor/twig/twig/lib/Twig/SimpleTest.php
@@ -27,6 +27,8 @@ class Twig_SimpleTest
         $this->options = array_merge(array(
             'is_variadic' => false,
             'node_class' => 'Twig_Node_Expression_Test',
+            'deprecated' => false,
+            'alternative' => null,
         ), $options);
     }
 
@@ -48,5 +50,20 @@ class Twig_SimpleTest
     public function isVariadic()
     {
         return $this->options['is_variadic'];
+    }
+
+    public function isDeprecated()
+    {
+        return (bool) $this->options['deprecated'];
+    }
+
+    public function getDeprecatedVersion()
+    {
+        return $this->options['deprecated'];
+    }
+
+    public function getAlternative()
+    {
+        return $this->options['alternative'];
     }
 }


### PR DESCRIPTION
It might be worth updating all the dependencies, instead of just fixing this file. 